### PR TITLE
Use board state in puzzle board and squares

### DIFF
--- a/src/components/action/content/BoardSetup.jsx
+++ b/src/components/action/content/BoardSetup.jsx
@@ -1,15 +1,18 @@
 import { useMemo } from 'react';
 import ActionButton from '../common/ActionButton';
+import { useDispatch } from 'react-redux';
+import { resetBoard } from '../../../services/slices/boardState';
 
 /**
  * The board setup action group contains the controls to setup the puzzle board as desired
  * @param {{theme: import('../ActionGroup').ActionThemes}} props
  */
 const BoardSetup = ({ theme='light' }) => {
+  const dispatch = useDispatch();
   const themePrefix = useMemo(() => `boardsetup-${theme}group`, [theme]);
 
   const zeroBoard = async () => {
-    alert('Zeroing board not yet implemented!');
+    dispatch(resetBoard());
   };
 
   return (

--- a/src/components/base/App.jsx
+++ b/src/components/base/App.jsx
@@ -1,14 +1,6 @@
+import { useSelector } from 'react-redux';
 import ActionList from '../action/ActionList';
 import PuzzleBoard from '../board/PuzzleBoard';
-
-const exampleBoardState = [
-  1, 0, 0, 0, 2, 0,
-  2, 1, 1, 0, 0, 0,
-  0, 1, 2, 0, 0, 0,
-  0, 0, 0, 0, 0, 0,
-  0, 0, 0, 2, 2, 1,
-  0, 0, 0, 1, 1, 0,
-];
 
 /** @type {[import('../action/ActionList').ActionParams]} */
 const testActions = [
@@ -19,9 +11,11 @@ const testActions = [
 ];
 
 const App = () => {
+  const gameBoardState = useSelector((state) => state.boardState.board);
+
   return (
     <div className="app-container">
-      <PuzzleBoard boardState={exampleBoardState} />
+      <PuzzleBoard boardState={gameBoardState} />
       <ActionList actions={testActions} />
     </div>
   );

--- a/src/components/board/PuzzleBoard.jsx
+++ b/src/components/board/PuzzleBoard.jsx
@@ -1,25 +1,36 @@
 import { useMemo } from 'react';
 import PuzzleRow from './PuzzleRow';
+import { useDispatch } from 'react-redux';
+import { cycleSquare } from '../../services/slices/boardState';
+
+const NUM_BOARD_ROWS = 6;
 
 /**
  * The Puzzle Board contains the puzzle itself
  * @param {{boardState: [number]}} props
  */
 const PuzzleBoard = ({ boardState }) => {
+  const dispatch = useDispatch();
+
   const rowValues = useMemo(() => {
     const lol = [];
-    for (let i = 0; i < 6; i++) {
-      lol.push(boardState.slice(i*6, (i+1)*6));
+    for (let i = 0; i < NUM_BOARD_ROWS; i++) {
+      lol.push(boardState.slice(i*NUM_BOARD_ROWS, (i+1)*NUM_BOARD_ROWS));
     }
     console.log(lol);
     return lol;
   }, [boardState]);
 
+  const onSquareClicked = (row, column) => {
+    const squareIndex = row * NUM_BOARD_ROWS + column;
+    dispatch(cycleSquare({ squareID: squareIndex, direction: 1 }))
+  }
+
   return (
     <div className="classpuzzle-container">
       <div className="classpuzzle-board">
-        {rowValues.map(states => (
-          <PuzzleRow squareStates={states} />
+        {rowValues.map((states, index) => (
+          <PuzzleRow squareStates={states} onRowClick={column => onSquareClicked(index, column)} />
         ))}
       </div>
     </div>

--- a/src/components/board/PuzzleRow.jsx
+++ b/src/components/board/PuzzleRow.jsx
@@ -1,10 +1,19 @@
 import { useMemo } from 'react';
 import PuzzleSquare from './PuzzleSquare';
 
-const PuzzleRow = ({ squareStates }) => {
+/**
+ * @typedef {Object} PuzzleRowProps
+ * @property {[number]} squareStates The numbers representing the states of each square
+ * @property {(number) => void} onRowClick The callback for clicking on a square
+ */
+
+/**
+ * @param {PuzzleRowProps} props
+ */
+const PuzzleRow = ({ squareStates, onRowClick }) => {
   const squares = useMemo(() => {
-    return squareStates.map(state => (
-      <PuzzleSquare squareState={state} />
+    return squareStates.map((state, index) => (
+      <PuzzleSquare squareState={state} onSquareClick={() => onRowClick(index)} />
     ));
   }, [squareStates]);
 

--- a/src/components/board/PuzzleSquare.jsx
+++ b/src/components/board/PuzzleSquare.jsx
@@ -1,12 +1,21 @@
 import { useMemo } from 'react';
 
-const PuzzleSquare = ({ squareState }) => {
+/**
+ * @typedef {Object} PuzzleSquareProps
+ * @property {number} squareState The state of the square
+ * @property {() => void} onSquareClick The callback for clicking the square
+ */
+
+/**
+ * @param {PuzzleSquareProps} props
+ */
+const PuzzleSquare = ({ squareState, onSquareClick }) => {
   const squareClasses = useMemo(() => {
     const isNonTrivialState = squareState > 0;
     return `classpuzzle-square ${isNonTrivialState ? `classpuzzle-square${squareState}` : ''}`;
   }, [squareState]);
 
-  return (<div className={squareClasses}>
+  return (<div className={squareClasses} onClick={onSquareClick}>
     Puzzle Square!
   </div>);
 };


### PR DESCRIPTION
We use the new redux state from the puzzle board to set states for squares. Clicking squares cycles their states and using the action buttons works now.